### PR TITLE
Route also running services (no service restart required)

### DIFF
--- a/docker-ingress-routing-daemon
+++ b/docker-ingress-routing-daemon
@@ -248,13 +248,20 @@ shopt -s lastpipe
 
 trap quit EXIT TERM INT
 
+# Check running services and
 # Watch for container start events, and configure policy routing rules on each container
 # to ensure return path traffic for incoming connections is routed back via the correct interface
 # and to the correct node from which the incoming connection was received.
+(
+docker ps \
+  --format '{{.ID}} {{.Label "com.docker.swarm.service.name"}}' \
+  --filter 'status=running' \
+  --filter "label=com.docker.swarm.service.name"
 docker events \
   --format '{{.ID}} {{index .Actor.Attributes "com.docker.swarm.service.name"}}' \
   --filter 'event=start' \
-  --filter 'type=container' | \
+  --filter 'type=container'
+) | \
   while read ID SERVICE
   do
     if [ -z "$SERVICE" ]; then


### PR DESCRIPTION
Just added a couple of lines so the daemon checks for already running services needing to be rerouted. This removes the need to restart services after docker-ingress-daemon start.

I tried hard to be less intrusive as possible on the upstream code for and ease merge. This could also be implemented differently (also tried thru a function which could also allow 'uninstalling' the rules on containers).

Let me know of any suggestion or change you consider
