### PR TITLE
Explicitly inspect network ingress

### DIFF
--- a/docker-ingress-routing-daemon
+++ b/docker-ingress-routing-daemon
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-VERSION=4.1.0
+VERSION=4.1.1
 
-# Ingress Routing Daemon v4.1.0
+# Ingress Routing Daemon v4.1.1
 # Copyright © 2020-2021 Struan Bartlett
 # ----------------------------------------------------------------------
 # Permission is hereby granted, free of charge, to any person 
@@ -44,7 +44,7 @@ quit() {
 
 detect_ingress() {
   read INGRESS_SUBNET INGRESS_DEFAULT_GATEWAY \
-    < <(docker inspect ingress --format '{{(index .IPAM.Config 0).Subnet}} {{index (split (index .Containers "ingress-sbox").IPv4Address "/") 0}}' 2>/dev/null)
+    < <(docker network inspect ingress --format '{{(index .IPAM.Config 0).Subnet}} {{index (split (index .Containers "ingress-sbox").IPv4Address "/") 0}}' 2>/dev/null)
 
   [ -n "$INGRESS_SUBNET" ] && [ -n "$INGRESS_DEFAULT_GATEWAY" ] && nsenter --net=/var/run/docker/netns/ingress_sbox iptables -L >/dev/null && return 0
   


### PR DESCRIPTION
"docker inspect ingress" relies on "ingress" being a network name and not used as container name ...
`docker run --name ingress hello-world ; docker inspect ingress` will happily return the inspect-json of the recently run container, instead of the network.
I suspect the same will be true for a service or stack named `ingress`.