### PR TITLE
feat: Adapt log format if journald is detected

### DIFF
--- a/docker-ingress-routing-daemon
+++ b/docker-ingress-routing-daemon
@@ -28,6 +28,13 @@ VERSION=4.1.1
 # Workaround for https://github.com/moby/moby/issues/25526
 
 log() {
+  if [ -n "${JOURNAL_STREAM}" ]
+  then
+    # Launched with systemd and journald
+    echo "$@"
+    return
+  fi
+
   [ -z "$_BASHPID" ] && _BASHPID="$BASHPID"
   local D=$(date +%Y-%m-%d.%H:%M:%S.%N)
   local S=$(printf "%s|%s|%05d|" "${D:0:26}" "$HOSTNAME" "$_BASHPID")


### PR DESCRIPTION
## Motivation

When the script is launched using `systemd` and `Journald`, system logs already has informations such as hostname, pid or datetime.

## Example

### Log before the patch

```
Jan 16 17:54:43 THE_HOSTNAME docker-ingress-routing-daemon[1623120]: 2024-01-16.17:54:43.099254|THE_HOSTNAME|1623097| Docker Ingress Routing Daemon 4.1.1 starting ...                                                                    
Jan 16 17:54:43 THE_HOSTNAME docker-ingress-routing-daemon[1623135]: 2024-01-16.17:54:43.123564|THE_HOSTNAME|1623097| Detecting ingress network and node IP:                                                                              
Jan 16 17:54:43 THE_HOSTNAME docker-ingress-routing-daemon[1623139]: 2024-01-16.17:54:43.127176|THE_HOSTNAME|1623097| - Ingress subnet: 10.0.0.0/24                                                                                       
Jan 16 17:54:43 THE_HOSTNAME docker-ingress-routing-daemon[1623143]: 2024-01-16.17:54:43.130406|THE_HOSTNAME|1623097| - This node's IP: 10.0.0.2 
```

### Log **after** the patch

```
Jan 16 18:08:42 THE_HOSTNAME docker-ingress-routing-daemon[1623972]: Docker Ingress Routing Daemon 4.1.1 starting ...                                                                
Jan 16 18:08:52 THE_HOSTNAME docker-ingress-routing-daemon[1623972]: Detecting ingress network and node IP:                                                                                                                              
Jan 16 18:08:52 THE_HOSTNAME docker-ingress-routing-daemon[1623972]: - Ingress subnet: 10.0.0.0/24                                                                                                                                       
Jan 16 18:08:52 THE_HOSTNAME docker-ingress-routing-daemon[1623972]: - This node's IP: 10.0.0.2
```