### PR TITLE
Use Actor.ID when formatting docker events output

### DIFF
--- a/docker-ingress-routing-daemon
+++ b/docker-ingress-routing-daemon
@@ -402,7 +402,7 @@ log "Launching docker event watcher to monitor for container launches (pgroup $$
 # to ensure return path traffic for incoming connections is routed back via the correct interface
 # and to the correct node from which the incoming connection was received.
 docker events \
-  --format '{{.ID}} {{index .Actor.Attributes "com.docker.swarm.service.name"}}' \
+  --format '{{.Actor.ID}} {{index .Actor.Attributes "com.docker.swarm.service.name"}}' \
   --filter 'event=start' \
   --filter 'type=container' | \
   while read ID SERVICE

--- a/docker-ingress-routing-daemon
+++ b/docker-ingress-routing-daemon
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-VERSION=4.2.0
+VERSION=4.3.0
 IPTABLES_OPTS=()
 
-# Ingress Routing Daemon v4.2.0
-# Copyright © 2020-2023 Struan Bartlett
+# Ingress Routing Daemon v4.3.0
+# Copyright © 2020-2025 Struan Bartlett
 # ----------------------------------------------------------------------
 # Permission is hereby granted, free of charge, to any person 
 # obtaining a copy of this software and associated documentation files 


### PR DESCRIPTION
## Summary
- use `.Actor.ID` in the `docker events` formatting string to remain compatible with API v1.52+
